### PR TITLE
feat: redesign portfolio with editorial/bold typography aesthetic

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 export default function Page() {
     return (
         <div className="flex flex-col items-center justify-center min-h-full py-24 text-center">
-            <div className="w-16 h-16 rounded-2xl bg-zinc-800 border border-zinc-700 flex items-center justify-center text-3xl mb-4">
-                📝
+            <div className="w-16 h-16 border border-[#1f1f1f] flex items-center justify-center text-[#444] font-mono text-sm mb-4">
+                —
             </div>
-            <h1 className="text-2xl font-bold text-white mb-2">Coming Soon</h1>
-            <p className="text-zinc-500 text-sm">Blog page is under development.</p>
+            <h1 className="text-2xl font-bold text-[#ededed] mb-2">Coming Soon</h1>
+            <p className="text-[#888] text-sm">Blog page is under development.</p>
         </div>
     )
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -31,52 +31,51 @@ export default function Page() {
 
     if (response !== '')
         return (
-            <section className="relative min-h-full flex items-center justify-center overflow-hidden">
-                <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,_rgba(168,85,247,0.08),_transparent_70%)] pointer-events-none" />
+            <section className="min-h-full flex items-center justify-center">
                 <div className="text-center">
-                    <div className="w-16 h-16 rounded-full bg-green-500/10 border border-green-500/30 flex items-center justify-center text-2xl mx-auto mb-4">✓</div>
-                    <h2 className="text-3xl font-bold text-white">{response}</h2>
+                    <div className="w-16 h-16 border border-[rgba(245,158,11,0.3)] flex items-center justify-center text-2xl text-[#f59e0b] mx-auto mb-4">✓</div>
+                    <h2 className="text-3xl font-bold text-[#ededed]">{response}</h2>
                 </div>
             </section>
         )
 
     return (
-        <section className="relative overflow-hidden">
-            <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(168,85,247,0.08),_transparent_60%)] pointer-events-none" />
-            <div className="relative py-8 lg:py-16 px-4 mx-auto max-w-screen-md">
-                <h2 className="mb-2 text-4xl tracking-tight font-extrabold text-center text-white">Get In Touch</h2>
-                <p className="text-center text-zinc-500 mb-8 text-sm">Have a project in mind or just want to say hi?</p>
+        <section>
+            <div className="py-8 lg:py-16 px-4 mx-auto max-w-screen-md">
+                <p className="font-mono text-xs text-[#444] tracking-widest uppercase mb-2 text-center">Contact</p>
+                <h2 className="mb-2 text-4xl tracking-tight font-extrabold text-center text-[#ededed]">Get In Touch</h2>
+                <p className="text-center text-[#888] mb-8 text-sm">Have a project in mind or just want to say hi?</p>
                 <form onSubmit={handleSubmit} className="space-y-6">
                     <div>
-                        <label htmlFor="email" className="block mb-2 text-sm font-medium text-zinc-400">Your email</label>
+                        <label htmlFor="email" className="block mb-2 text-sm font-mono text-[#888]">Your email</label>
                         <input
                             type="email" id="email" value={state.email}
                             onChange={(e) => handleChange(e, 'email')}
-                            className="w-full p-3 rounded-lg bg-zinc-900 border border-zinc-700 text-white placeholder-zinc-600 text-sm focus:outline-none focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors duration-200"
+                            className="w-full p-3 bg-[#141414] border border-[#1f1f1f] text-[#ededed] placeholder-[#444] text-sm focus:outline-none focus:border-[#f59e0b] transition-colors duration-200"
                             placeholder="name@email.com" required
                         />
                     </div>
                     <div>
-                        <label htmlFor="subject" className="block mb-2 text-sm font-medium text-zinc-400">Subject</label>
+                        <label htmlFor="subject" className="block mb-2 text-sm font-mono text-[#888]">Subject</label>
                         <input
                             type="text" id="subject" value={state.subject}
                             onChange={(e) => handleChange(e, 'subject')}
-                            className="w-full p-3 rounded-lg bg-zinc-900 border border-zinc-700 text-white placeholder-zinc-600 text-sm focus:outline-none focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors duration-200"
+                            className="w-full p-3 bg-[#141414] border border-[#1f1f1f] text-[#ededed] placeholder-[#444] text-sm focus:outline-none focus:border-[#f59e0b] transition-colors duration-200"
                             placeholder="What's this about?" required
                         />
                     </div>
                     <div>
-                        <label htmlFor="message" className="block mb-2 text-sm font-medium text-zinc-400">Message</label>
+                        <label htmlFor="message" className="block mb-2 text-sm font-mono text-[#888]">Message</label>
                         <textarea
                             id="message" rows={6} value={state.message}
                             onChange={(e) => handleChange(e, 'message')}
-                            className="w-full p-3 rounded-lg bg-zinc-900 border border-zinc-700 text-white placeholder-zinc-600 text-sm focus:outline-none focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors duration-200 resize-none"
+                            className="w-full p-3 bg-[#141414] border border-[#1f1f1f] text-[#ededed] placeholder-[#444] text-sm focus:outline-none focus:border-[#f59e0b] transition-colors duration-200 resize-none"
                             placeholder="Tell me what's on your mind..."
                         />
                     </div>
                     <button
                         type="submit"
-                        className="w-full sm:w-auto px-8 py-3 rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold transition-all duration-300 hover:from-purple-500 hover:to-blue-500 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/30"
+                        className="w-full sm:w-auto px-8 py-3 border border-[#f59e0b] text-[#f59e0b] font-mono text-sm tracking-wide transition-colors duration-200 hover:bg-[rgba(245,158,11,0.1)]"
                     >
                         Send Message
                     </button>

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -44,7 +44,7 @@ const EXPERIENCE: ExperienceItem[] = [
 ]
 
 const ToolBadge = ({ name }: { name: string }) => (
-  <span className="px-2.5 py-1 text-xs rounded-md bg-zinc-800 border border-zinc-700 text-zinc-300 hover:border-purple-500/50 hover:text-purple-300 transition-all duration-200 cursor-default">
+  <span className="px-2.5 py-1 text-xs font-mono bg-[#141414] border border-[#1f1f1f] text-[#888] hover:border-[rgba(245,158,11,0.3)] hover:text-[#f59e0b] transition-all duration-200 cursor-default">
     {name}
   </span>
 )
@@ -53,40 +53,40 @@ const ExperienceCard = ({ item, index }: { item: ExperienceItem; index: number }
   <div className="relative flex gap-6">
     {/* Timeline spine */}
     <div className="flex flex-col items-center">
-      <div className={`w-3 h-3 rounded-full mt-1.5 shrink-0 ring-4 ring-zinc-950 ${item.current ? 'bg-purple-500' : 'bg-zinc-600'}`} />
+      <div className={`w-3 h-3 mt-1.5 shrink-0 ring-4 ring-[#0c0c0c] ${item.current ? 'bg-[#f59e0b]' : 'bg-[#444]'}`} />
       {index < EXPERIENCE.length - 1 && (
-        <div className="w-px flex-1 bg-zinc-800 mt-1" />
+        <div className="w-px flex-1 bg-[#1f1f1f] mt-1" />
       )}
     </div>
 
     {/* Card */}
     <div className="pb-10 flex-1">
-      <div className="p-6 rounded-xl border border-zinc-800 bg-zinc-900/50 hover:border-zinc-700 transition-all duration-300 hover:shadow-lg hover:shadow-black/30 group">
+      <div className="p-6 border border-[#1f1f1f] bg-[#141414] hover:border-[#2d2d2d] transition-all duration-300 hover:shadow-lg hover:shadow-black/30 group">
         {/* Header */}
         <div className="flex flex-wrap items-start justify-between gap-2 mb-4">
           <div>
             <div className="flex items-center gap-2 mb-1">
-              <h2 className="text-lg font-bold text-white group-hover:text-purple-300 transition-colors duration-200">
+              <h2 className="text-lg font-bold text-[#ededed] group-hover:text-[#f59e0b] transition-colors duration-200">
                 {item.role}
               </h2>
               {item.current && (
-                <span className="px-2 py-0.5 text-xs rounded-full bg-purple-500/15 border border-purple-500/30 text-purple-300 font-medium">
+                <span className="px-2 py-0.5 text-xs font-mono border border-[rgba(245,158,11,0.3)] bg-[rgba(245,158,11,0.1)] text-[#f59e0b]">
                   Current
                 </span>
               )}
             </div>
-            <p className="text-sm text-zinc-400">
-              {item.company} <span className="text-zinc-600">·</span> {item.location}
+            <p className="text-sm text-[#888]">
+              {item.company} <span className="text-[#2d2d2d]">·</span> {item.location}
             </p>
           </div>
-          <span className="text-xs text-zinc-500 whitespace-nowrap mt-1">{item.period}</span>
+          <span className="text-xs font-mono text-[#444] whitespace-nowrap mt-1">{item.period}</span>
         </div>
 
         {/* Bullets */}
         <ul className="space-y-2 mb-5">
           {item.bullets.map((b, i) => (
-            <li key={i} className="text-sm text-zinc-400 flex gap-2">
-              <span className="text-purple-500 mt-0.5 shrink-0">›</span>
+            <li key={i} className="text-sm text-[#888] flex gap-2">
+              <span className="text-[#f59e0b] mt-0.5 shrink-0">›</span>
               {b}
             </li>
           ))}
@@ -103,20 +103,15 @@ const ExperienceCard = ({ item, index }: { item: ExperienceItem; index: number }
 
 export default function Page() {
   return (
-    <div className="relative overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,_rgba(168,85,247,0.08),_transparent_60%)] pointer-events-none" />
-      <div className="relative max-w-3xl mx-auto px-4 py-10">
+    <div className="relative max-w-3xl mx-auto px-4 py-10">
+      <p className="font-mono text-xs text-[#444] tracking-widest uppercase mb-2">Career</p>
+      <h1 className="text-3xl font-bold text-[#ededed] mb-10">Experience</h1>
 
-        <h1 className="text-3xl font-bold text-white mb-10">Experience</h1>
-
-        {/* Timeline */}
-        <div>
-          {EXPERIENCE.map((item, index) => (
-            <ExperienceCard key={index} item={item} index={index} />
-          ))}
-        </div>
-
-
+      {/* Timeline */}
+      <div>
+        {EXPERIENCE.map((item, index) => (
+          <ExperienceCard key={index} item={item} index={index} />
+        ))}
       </div>
     </div>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,21 @@ import React from 'react'
 import '../styles/globals.css'
 import Head from "next/head";
 import Navigationbar from '../components/NavigationBar';
+import { Space_Grotesk, JetBrains_Mono } from 'next/font/google'
+
+const spaceGrotesk = Space_Grotesk({
+    subsets: ['latin'],
+    weight: ['400', '500', '600', '700'],
+    variable: '--font-space-grotesk',
+    display: 'swap',
+})
+
+const jetbrainsMono = JetBrains_Mono({
+    subsets: ['latin'],
+    weight: ['400', '500'],
+    variable: '--font-jetbrains-mono',
+    display: 'swap',
+})
 
 export default function RootLayout({
     children
@@ -9,22 +24,22 @@ export default function RootLayout({
     children: React.ReactNode
 }) {
     return (
-    <html>
+    <html className={`${spaceGrotesk.variable} ${jetbrainsMono.variable}`}>
         <Head>
           <title>Pranesh Shrestha</title>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <title>Pranesh Shrestha | Portfolio</title>
         </Head>
-        
-        <body className="min-h-screen dark:bg-zinc-950 dark:text-white flex flex-col">
+
+        <body className="min-h-screen bg-[#0c0c0c] text-[#ededed] font-sans flex flex-col">
             <Navigationbar />
             <main className="flex-grow w-full">
                 {children}
             </main>
-            <footer className="border-t border-zinc-300/10 w-full bg-zinc-950/80">
+            <footer className="border-t border-[#1f1f1f] w-full bg-[#0c0c0c]/90">
                 <div className="max-w-screen-xl mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-3">
-                    <p className="text-xs text-zinc-600">
+                    <p className="text-xs text-[#444]">
                         © {new Date().getFullYear()} Pranesh Shrestha. All rights reserved.
                     </p>
                     <div className="flex items-center gap-1">
@@ -61,7 +76,7 @@ export default function RootLayout({
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 aria-label={label}
-                                className="text-zinc-500 hover:text-white transition-all duration-200 p-2 rounded-lg hover:bg-zinc-800 hover:scale-110"
+                                className="text-[#444] hover:text-[#ededed] transition-all duration-200 p-2 hover:bg-[#1f1f1f]"
                             >
                                 {svg}
                             </a>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,113 +1,94 @@
-'use client'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import Image from "next/image"
 import Link from "next/link"
 import List from '../components/List'
 
-function useTypewriter(text: string, speed = 40) {
-  const [displayed, setDisplayed] = useState('')
-  useEffect(() => {
-    setDisplayed('')
-    let i = 0
-    const interval = setInterval(() => {
-      setDisplayed(text.slice(0, i + 1))
-      i++
-      if (i >= text.length) clearInterval(interval)
-    }, speed)
-    return () => clearInterval(interval)
-  }, [text, speed])
-  return displayed
-}
-
 const TECH = ['React', 'Next.js', 'TypeScript', 'Python', 'GraphQL']
 
 export default function Page() {
-  const subtitle = useTypewriter('Software Engineer at Meta. Welcome to my portfolio.')
-
   return (
-    <section className="relative">
-      {/* Radial glow background — fixed so it always fills the viewport */}
-      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top_left,_rgba(168,85,247,0.15),_transparent_60%)] pointer-events-none -z-10" />
-      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_bottom_right,_rgba(59,130,246,0.10),_transparent_60%)] pointer-events-none -z-10" />
+    <section>
+      <div className="max-w-screen-xl px-4 pt-16 pb-8 mx-auto">
 
-      <div className="relative grid max-w-screen-xl px-4 py-8 mx-auto lg:gap-8 xl:gap-0 lg:py-16 lg:grid-cols-12 items-center">
+        {/* Metadata row — monospace, muted */}
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-1 mb-12 font-mono text-xs text-[#777] tracking-widest uppercase hero-fade-in">
+          <span>Software Engineer</span>
+          <span className="text-[#444]">—</span>
+          <span>Meta · Menlo Park, CA</span>
+          <span className="text-[#444]">—</span>
+          <span>2024 – Present</span>
+        </div>
 
-        {/* Left: Text content */}
-        <div className="mr-auto place-self-center lg:col-span-7 hero-fade-in">
-
-          {/* Availability badge */}
-          <div className="inline-flex items-center gap-2 px-3 py-1 mb-6 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 text-sm">
-            <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
-            Available for new opportunities
-          </div>
-
-          <h1 className="max-w-2xl mb-2 text-4xl font-extrabold tracking-tight leading-none md:text-5xl xl:text-6xl dark:text-white hero-slide-up">
-            Hi There. 👋
-          </h1>
-          <h1 className="max-w-2xl mb-4 text-4xl font-extrabold tracking-tight leading-none md:text-5xl xl:text-6xl hero-gradient-text hero-slide-up-delay">
-            I am Pranesh Shrestha
+        {/* Name + photo row */}
+        <div className="flex items-start justify-between gap-8">
+          <h1
+            className="font-bold leading-[0.9] tracking-tight text-[#ededed] hero-name-reveal"
+            style={{ fontSize: 'clamp(3.5rem, 10vw, 8rem)' }}
+          >
+            Pranesh<br />Shrestha
           </h1>
 
-          <p className="max-w-2xl mb-8 font-light text-gray-500 lg:mb-10 md:text-lg lg:text-xl dark:text-gray-400 min-h-[60px]">
-            {subtitle}
-            <span className="hero-cursor">|</span>
-          </p>
-
-          {/* CTA buttons */}
-          <div className="flex flex-wrap gap-4 mb-8">
-            <Link
-              href="/experience"
-              className="px-6 py-3 rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold transition-all duration-300 hover:from-purple-500 hover:to-blue-500 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/30"
-            >
-              View Experience
-            </Link>
-            <Link
-              href="/contact"
-              className="px-6 py-3 rounded-lg border border-zinc-600 text-zinc-300 font-semibold transition-all duration-300 hover:border-purple-500 hover:text-purple-300 hover:scale-105"
-            >
-              Get In Touch
-            </Link>
-          </div>
-
-          {/* Tech stack pills */}
-          <div className="flex flex-wrap gap-2">
-            {TECH.map((tech) => (
-              <span
-                key={tech}
-                className="px-3 py-1 text-xs rounded-full border border-zinc-700 text-zinc-400 transition-all duration-200 hover:border-purple-500/60 hover:text-purple-300 cursor-default"
-              >
-                {tech}
-              </span>
-            ))}
+          {/* Profile photo — toned down, no glow */}
+          <div className="hidden lg:block shrink-0 w-40 opacity-60 grayscale hover:opacity-100 hover:grayscale-0 transition-all duration-500">
+            <div className="border border-[#1f1f1f] overflow-hidden">
+              <Image
+                src="/images/profile.jpg"
+                alt="Pranesh Shrestha"
+                height={220}
+                width={160}
+                className="object-cover"
+              />
+            </div>
           </div>
         </div>
 
-        {/* Right: Profile image */}
-        <div className="hidden lg:flex lg:mt-0 lg:col-span-5 justify-center items-center">
-          <div className="relative group">
-            {/* Animated glow ring */}
-            <div className="absolute -inset-1 rounded-2xl bg-gradient-to-r from-purple-600 to-blue-500 opacity-60 blur-sm group-hover:opacity-90 transition-opacity duration-500 hero-glow-pulse" />
-            <div className="relative rounded-2xl overflow-hidden border border-zinc-700/50">
-              <Image
-                src="/images/profile.jpg"
-                alt="mypic"
-                height={500}
-                width={500}
-                className="object-cover grayscale-[15%] group-hover:grayscale-0 transition-all duration-500 group-hover:scale-[1.02]"
-              />
+        {/* Description + CTAs */}
+        <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8 mt-12 hero-slide-up-delay">
+          <p className="max-w-md text-base text-[#aaa] leading-relaxed">
+            Building agentic workflows, AI orchestration systems, and
+            MCP tool infrastructure at Meta. Previously React component
+            systems and WebAssembly at Microchip Technology.
+          </p>
+
+          <div className="flex flex-col gap-4 lg:items-end">
+            <div className="w-12 h-px bg-[#f59e0b]" />
+            <div className="flex gap-3">
+              <Link
+                href="/experience"
+                className="px-5 py-2.5 border border-[#f59e0b] text-[#f59e0b] text-sm font-mono tracking-wide transition-colors duration-200 hover:bg-[rgba(245,158,11,0.1)]"
+              >
+                Experience
+              </Link>
+              <Link
+                href="/contact"
+                className="px-5 py-2.5 border border-[#333] text-[#aaa] text-sm font-mono tracking-wide transition-colors duration-200 hover:border-[#555] hover:text-[#ededed]"
+              >
+                Contact
+              </Link>
             </div>
           </div>
         </div>
 
       </div>
 
-      {/* Skills section */}
-      <div className="relative max-w-screen-xl px-4 pb-12 mx-auto">
-        <div className="border-t border-zinc-800 pt-10">
-          <List />
+      {/* Tech stack row */}
+      <div className="max-w-screen-xl px-4 py-6 mx-auto hero-fade-in">
+        <div className="border-t border-[#1f1f1f] pt-6 flex flex-wrap items-center gap-x-6 gap-y-2">
+          <span className="font-mono text-xs text-[#666] tracking-widest uppercase">Stack</span>
+          {TECH.map(t => (
+            <span key={t} className="font-mono text-xs text-[#aaa] hover:text-[#f59e0b] transition-colors duration-150 cursor-default">
+              {t}
+            </span>
+          ))}
         </div>
       </div>
 
+      {/* Skills section */}
+      <div className="max-w-screen-xl px-4 pb-12 mx-auto">
+        <div className="border-t border-[#1f1f1f] pt-10">
+          <List />
+        </div>
+      </div>
     </section>
   )
 }

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,20 +1,19 @@
 import * as React from "react";
 
 const SkillBadge = ({ name }: { name: string }) => (
-  <span className="px-2.5 py-1 text-xs rounded-md bg-zinc-800 border border-zinc-700 text-zinc-300 hover:border-purple-500/50 hover:text-purple-300 transition-all duration-200 cursor-default">
+  <span className="px-2.5 py-1 text-xs font-mono bg-[#141414] border border-[#1f1f1f] text-[#888] hover:border-[rgba(245,158,11,0.3)] hover:text-[#f59e0b] transition-all duration-200 cursor-default">
     {name}
   </span>
 )
 
 type CategoryCardProps = {
   title: string
-  accent: string
   skills: string[]
 }
 
-const CategoryCard = ({ title, accent, skills }: CategoryCardProps) => (
-  <div className="min-w-[200px] p-5 rounded-xl border border-zinc-800 bg-zinc-900/50 hover:border-zinc-600 transition-all duration-200 hover:shadow-lg hover:shadow-black/30">
-    <h2 className={`mb-3 text-xs font-semibold uppercase tracking-wider ${accent}`}>
+const CategoryCard = ({ title, skills }: CategoryCardProps) => (
+  <div className="min-w-[200px] p-5 border border-[#1f1f1f] bg-[#141414] hover:border-[#2d2d2d] transition-all duration-200 hover:shadow-lg hover:shadow-black/30">
+    <h2 className="mb-3 text-xs font-mono font-medium uppercase tracking-wider text-[#444]">
       {title}
     </h2>
     <div className="flex flex-wrap gap-2">
@@ -26,31 +25,26 @@ const CategoryCard = ({ title, accent, skills }: CategoryCardProps) => (
 const List = () => {
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-white mb-6">Skills</h1>
+      <h1 className="text-2xl font-bold text-[#ededed] mb-6">Skills</h1>
       <div className="flex flex-wrap gap-4">
         <CategoryCard
           title="Languages"
-          accent="text-purple-400"
           skills={['TypeScript', 'Python', 'Go', 'C/C++', 'Rust', 'Hack', 'SQL']}
         />
         <CategoryCard
           title="Frameworks & Libraries"
-          accent="text-green-400"
           skills={['React', 'Next.js', 'Node.js', 'Vite', 'Relay']}
         />
         <CategoryCard
           title="Infrastructure & Data"
-          accent="text-blue-400"
           skills={['MySQL', 'Redis', 'GCloud', 'Hive', 'Scuba', 'MCP']}
         />
         <CategoryCard
           title="Dev Tools"
-          accent="text-yellow-400"
           skills={['Git', 'Bazel', 'JIRA', 'Claude Code']}
         />
         <CategoryCard
           title="Testing"
-          accent="text-rose-400"
           skills={['Vitest', 'Playwright', 'Google Test', 'Jest']}
         />
       </div>

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,31 +1,72 @@
-import React from "react";
+"use client";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import NavItem from "./NavigationItem";
 
 export default function Navigationbar() {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
   return (
-    <nav className="w-full border-b border-zinc-300/10 backdrop-blur-sm bg-zinc-950/80 sticky top-0 z-50">
+    <nav className="w-full border-b border-[#1f1f1f] backdrop-blur-sm bg-[#0c0c0c]/90 sticky top-0 z-50">
       <div className="max-w-screen-xl mx-auto px-4 flex items-center justify-between h-14">
 
         {/* Logo / Name */}
         <Link href="/" className="flex items-center gap-2 group">
-          <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-purple-600 to-blue-600 flex items-center justify-center text-white text-sm font-bold shrink-0 group-hover:shadow-lg group-hover:shadow-purple-500/30 transition-all duration-200">
-            P
+          <div className="w-8 h-8 border border-[#f59e0b] flex items-center justify-center text-[#f59e0b] font-mono text-xs font-medium shrink-0 transition-all duration-200">
+            PS
           </div>
-          <span className="font-semibold text-sm text-zinc-300 group-hover:text-white transition-colors duration-200 hidden sm:block">
+          <span className="font-medium text-sm text-[#888] group-hover:text-[#ededed] transition-colors duration-200 hidden sm:block">
             Pranesh Shrestha
           </span>
         </Link>
 
-        {/* Nav links */}
-        <ul className="flex flex-row items-center pl-0">
+        {/* Desktop nav links */}
+        <ul className="hidden sm:flex flex-row items-center pl-0">
           <NavItem routes="/experience">Experience</NavItem>
           <NavItem routes="/projects">Projects</NavItem>
           <NavItem routes="/blog">Blog</NavItem>
           <NavItem routes="/contact">Contact</NavItem>
         </ul>
 
+        {/* Hamburger button — mobile only */}
+        <button
+          onClick={() => setIsOpen(o => !o)}
+          className="sm:hidden flex items-center justify-center p-2 text-[#888] hover:text-[#ededed] transition-colors duration-200"
+          aria-label="Toggle menu"
+        >
+          {isOpen ? (
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <line x1="1" y1="1" x2="17" y2="17"/>
+              <line x1="17" y1="1" x2="1" y2="17"/>
+            </svg>
+          ) : (
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <line x1="0" y1="4" x2="18" y2="4"/>
+              <line x1="0" y1="9" x2="18" y2="9"/>
+              <line x1="0" y1="14" x2="18" y2="14"/>
+            </svg>
+          )}
+        </button>
+
       </div>
+
+      {/* Mobile dropdown */}
+      {isOpen && (
+        <div className="sm:hidden border-t border-[#1f1f1f] bg-[#0c0c0c]">
+          <div className="max-w-screen-xl mx-auto px-4 py-2 flex flex-col">
+            <NavItem routes="/experience" onClick={() => setIsOpen(false)}>Experience</NavItem>
+            <NavItem routes="/projects" onClick={() => setIsOpen(false)}>Projects</NavItem>
+            <NavItem routes="/blog" onClick={() => setIsOpen(false)}>Blog</NavItem>
+            <NavItem routes="/contact" onClick={() => setIsOpen(false)}>Contact</NavItem>
+          </div>
+        </div>
+      )}
     </nav>
   );
 }

--- a/src/components/NavigationItem.tsx
+++ b/src/components/NavigationItem.tsx
@@ -6,6 +6,7 @@ import classNames from "../util/classNames";
 type NavItemProps = {
     children: React.ReactNode,
     routes: string
+    onClick?: () => void
 }
 
 const NavItem = (props: NavItemProps) => {
@@ -14,14 +15,15 @@ const NavItem = (props: NavItemProps) => {
     return (
         <Link
             href={props.routes}
+            onClick={props.onClick}
             className={classNames(
                 "relative text-sm px-4 py-5 inline-block transition-colors duration-200",
-                isActive ? "text-white" : "text-zinc-500 hover:text-zinc-200"
+                isActive ? "text-[#ededed]" : "text-[#444] hover:text-[#888]"
             )}
         >
             {props.children}
             {isActive && (
-                <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-4/5 h-0.5 rounded-full bg-gradient-to-r from-purple-500 to-blue-500" />
+                <span className="absolute bottom-0 left-0 w-full h-px bg-[#f59e0b]" />
             )}
         </Link>
     )

--- a/src/components/projectlist.tsx
+++ b/src/components/projectlist.tsx
@@ -5,11 +5,11 @@ type Role = 'leader' | 'member' | 'engineer';
 const roleStyles: Record<Role, string> = {
   leader:   'bg-green-500/10 text-green-400 border-green-500/30',
   member:   'bg-blue-500/10 text-blue-400 border-blue-500/30',
-  engineer: 'bg-purple-500/10 text-purple-400 border-purple-500/30',
+  engineer: 'bg-[rgba(245,158,11,0.1)] text-[#f59e0b] border-[rgba(245,158,11,0.3)]',
 };
 
 const RoleBadge = ({ role, label }: { role: Role; label: string }) => (
-  <span className={`px-2.5 py-0.5 text-xs rounded-full border font-medium ${roleStyles[role]}`}>
+  <span className={`px-2.5 py-0.5 text-xs border font-mono font-medium ${roleStyles[role]}`}>
     {label}
   </span>
 );
@@ -23,20 +23,20 @@ type ProjectCardProps = {
 };
 
 const ProjectCard = ({ role, title, org, date, items }: ProjectCardProps) => (
-  <div className="w-[90%] sm:w-3/5 p-6 rounded-xl border border-zinc-800 bg-zinc-900/50 hover:border-purple-500/30 hover:shadow-lg hover:shadow-purple-500/5 transition-all duration-300 group">
+  <div className="w-[90%] sm:w-3/5 p-6 border border-[#1f1f1f] bg-[#141414] hover:border-[#2d2d2d] hover:shadow-lg hover:shadow-black/20 transition-all duration-300 group">
     <div className="flex flex-wrap items-start justify-between gap-2 mb-4">
       <div className="flex flex-col gap-1">
         <RoleBadge role={role} label={title} />
-        <h3 className="text-base font-semibold text-white group-hover:text-purple-300 transition-colors duration-200">
+        <h3 className="text-base font-semibold text-[#ededed] group-hover:text-[#f59e0b] transition-colors duration-200">
           {org}
         </h3>
       </div>
-      <span className="text-xs text-zinc-500 whitespace-nowrap mt-1">{date}</span>
+      <span className="text-xs font-mono text-[#444] whitespace-nowrap mt-1">{date}</span>
     </div>
     <ul className="space-y-2">
       {items.map((item, idx) => (
-        <li key={idx} className="text-sm text-zinc-400 flex gap-2">
-          <span className="text-purple-500 mt-0.5 shrink-0">›</span>
+        <li key={idx} className="text-sm text-[#888] flex gap-2">
+          <span className="text-[#f59e0b] mt-0.5 shrink-0">›</span>
           {item}
         </li>
       ))}
@@ -47,7 +47,7 @@ const ProjectCard = ({ role, title, org, date, items }: ProjectCardProps) => (
 const ProjectList = () => {
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-white mb-6">Projects</h1>
+      <h1 className="text-2xl font-bold text-[#ededed] mb-6">Projects</h1>
       <div className="flex flex-col gap-4 items-center w-full">
         <ProjectCard
           role="engineer"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,15 @@
 @import 'tailwindcss';
 
+@theme {
+  --color-surface: #141414;
+  --color-border: #1f1f1f;
+  --color-border-hover: #2d2d2d;
+  --color-text: #ededed;
+  --color-text-secondary: #888888;
+  --color-text-muted: #444444;
+  --color-accent: #f59e0b;
+}
+
 /* ── Hero page animations ─────────────────────────────────── */
 
 @keyframes heroFadeIn {
@@ -12,19 +22,9 @@
   to   { opacity: 1; transform: translateY(0);    }
 }
 
-@keyframes heroGradientShift {
-  0%,100% { background-position: 0%   50%; }
-  50%      { background-position: 100% 50%; }
-}
-
-@keyframes heroBlink {
-  0%,100% { opacity: 1; }
-  50%     { opacity: 0; }
-}
-
-@keyframes heroGlowPulse {
-  0%,100% { opacity: 0.6; }
-  50%     { opacity: 0.35; }
+@keyframes heroReveal {
+  from { clip-path: inset(0 100% 0 0); opacity: 0; }
+  to   { clip-path: inset(0 0% 0 0);   opacity: 1; }
 }
 
 .hero-fade-in {
@@ -40,20 +40,7 @@
   animation: heroSlideUp 0.6s ease-out 0.2s forwards;
 }
 
-.hero-gradient-text {
-  background: linear-gradient(135deg, #a855f7, #ec4899, #3b82f6);
-  background-size: 200% 200%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: heroGradientShift 5s ease infinite;
-}
-
-.hero-cursor {
-  animation: heroBlink 1s step-end infinite;
-  margin-left: 1px;
-}
-
-.hero-glow-pulse {
-  animation: heroGlowPulse 3s ease-in-out infinite;
+.hero-name-reveal {
+  animation: heroReveal 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards;
+  opacity: 0;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,12 @@ import typography from '@tailwindcss/typography'
 export default {
     content: ["./src/**/*.{js,ts,jsx,tsx}"],
     theme: {
-      extend: {},
+      extend: {
+        fontFamily: {
+          sans: ['var(--font-space-grotesk)', 'system-ui', 'sans-serif'],
+          mono: ['var(--font-jetbrains-mono)', 'monospace'],
+        },
+      },
     },
     plugins: [
       typography,


### PR DESCRIPTION
- Replace purple/blue gradient system with amber (#f59e0b) single accent
- Add Space Grotesk + JetBrains Mono fonts via next/font/google
- Overhaul hero: large typographic name, monospace metadata row, flat outlined CTAs
- Remove typewriter effect, glow orbs, gradient animations, pulsing badge
- Sharp-cornered cards and badges across all pages (no rounded-xl)
- Add hamburger menu for mobile with dropdown navigation
- Consistent amber hover states and active indicators site-wide